### PR TITLE
Fix link for Exporting a Private Certificate

### DIFF
--- a/doc_source/PcaGetCert.md
+++ b/doc_source/PcaGetCert.md
@@ -1,6 +1,6 @@
 # Retrieving Private Certificates<a name="PcaGetCert"></a>
 
-You can use the ACM Private CA API and AWS CLI to issue a private certificate\. If you do, you can use the AWS CLI or ACM Private CA API to retrieve that certificate\. If you used ACM to create your private CA and to request certificates, you must use ACM to export the certificate and the encrypted private key\. For more information, see [Exporting a Private Certificate](https://docs.aws.amazon.com/acm/latest/userguide/gs-acm-export-private.html)\. 
+You can use the ACM Private CA API and AWS CLI to issue a private certificate\. If you do, you can use the AWS CLI or ACM Private CA API to retrieve that certificate\. If you used ACM to create your private CA and to request certificates, you must use ACM to export the certificate and the encrypted private key\. For more information, see [Exporting a Private Certificate](https://docs.aws.amazon.com/acm/latest/userguide/export-private.html)\. 
 
 **To retrieve an end\-entity certificate**  
 Use the [get\-certificate](https://docs.aws.amazon.com/cli/latest/reference/acm-pca/get-certificate.html) AWS CLI command to retrieve a private end\-entity certificate\. You can also use the [GetCertificate](https://docs.aws.amazon.com/acm-pca/latest/APIReference/API_GetCertificate.html) API operation\. Use the `--output text` option to output the certificate without <CR><LF> pairs\. 


### PR DESCRIPTION
*Description of changes:* Fix the link to the documentation how to export a private certificate.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
