### PR TITLE
Add Amazon WorkSpaces as a supported service for short-lived certificates

### DIFF
--- a/doc_source/short-lived-certificates.md
+++ b/doc_source/short-lived-certificates.md
@@ -22,3 +22,4 @@ AWS Certificate Manager cannot issue certificates signed by a private CA with sh
 
 Use of short\-lived certificates is supported by the following AWS services:
 + [Amazon AppStream](https://docs.aws.amazon.com/appstream/latest/developerguide/)
++ [Amazon WorkSpaces](https://docs.aws.amazon.com/workspaces/latest/adminguide/certificate-based-authentication.html)


### PR DESCRIPTION
*Description of changes:*

This adds Amazon WorkSpaces to the list of supported services, with a link to the certificate based authentication page.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
