### PR TITLE
Update PCACertInstall.md

### DIFF
--- a/doc_source/PCACertInstall.md
+++ b/doc_source/PCACertInstall.md
@@ -150,7 +150,7 @@ If you are using AWS CLI version 1\.6\.3 or later, use the prefix `fileb://` whe
    ```
    $ aws acm-pca issue-certificate \
         --certificate-authority-arn arn:aws:acm-pca:region:account:certificate-authority/CA_ID \
-        --csr file://ca.csr \
+        --csr fileb://ca.csr \
         --signing-algorithm SHA256WITHRSA \
         --template-arn arn:aws:acm-pca:::template/RootCACertificate/V1 \
         --validity Value=365,Type=DAYS
@@ -267,7 +267,7 @@ If you are using AWS CLI version 1\.6\.3 or later, use the prefix `fileb://` whe
    ```
    $ aws acm-pca import-certificate-authority-certificate \
         --certificate-authority-arn arn:aws:acm-pca:region:account:certificate-authority/CA_ID \
-        --certificate file://cert.pem
+        --certificate fileb://cert.pem
    ```
 
 Inspect the new status of the CA\.


### PR DESCRIPTION
Since the 'issue-certificate' and 'import-certificate-authority-certificate' commands only use binary files (blobs), changing the commands to use the 'fileb' extension so as not to confuse customers. This formatting is already used in other parts of the documentation (https://docs.aws.amazon.com/privateca/latest/userguide/PcaIssueCert.html)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
